### PR TITLE
override bootstrap styling to fix #69

### DIFF
--- a/app/styles/layout/_inputs.scss
+++ b/app/styles/layout/_inputs.scss
@@ -17,6 +17,15 @@
     display: block !important;
 }
 
+.form-group.is-focused {
+    //.variations(unquote(".is-focused label.control-label"), color, $brand-primary); // focused label color variations
+    label,
+    label.control-label {
+      color: inherit;
+    }
+}
+
+
 input[type=number].pin-digit {
   -webkit-text-security: disc;
   width: 20%;


### PR DESCRIPTION
Fixed Issue #69 by overriding the bootstrap styling (color is a bit brighter post-selection than pre, but IMO that's even better than no change from a UI perspective). 

I'm filing this as a PR because I haven't done much with bootstrap or SASS before, so I'd like @Jakeii's opinion before committing. Maybe @neerajkamdar will also have thoughts to share?