### PR TITLE
Fix for Certell logo being cut off on small screens

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -16,6 +16,11 @@ body {
   margin-bottom: 3em;
 }
 
+.certel-logo img{
+  width: 100%;
+  max-width: 365px;
+}
+
 .user-list {
   max-height: 84px * 3;
   overflow-y: scroll;


### PR DESCRIPTION
This should fix Ryan's issue number 2 of the Certell logo being cutoff. 