### PR TITLE
Added styles for Video Links within book

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -284,3 +284,52 @@ blockquote {
     }
 }
 
+a.video_link {
+    line-height: 1em;
+    position: relative;
+    border: 1px solid $brand-primary;
+    margin: 1em 1em 1em 0em;
+    padding: 0.9em 1em 1em 3em;
+    border-radius: 1000px;
+    background: transparent;
+    color: $brand-primary;
+    text-decoration: none;
+    display: table;
+    
+    &:before {
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 0.6em 0em 0.6em 0.9em;
+        border-color: transparent transparent transparent #FFFFFF;
+        left: 1.2em;
+        position: absolute;
+        content: '';
+        padding: 0;
+        top: 0.8em;
+        z-index: 1;
+        -webkit-transform: rotate(360deg);
+    }
+
+    &:after {
+        position: absolute;
+        content: '';
+        padding: 1em;
+        border: 1px solid $brand-primary;
+        border-radius: 1000px;
+        line-height: 1;
+        background-color: $brand-primary;
+        left: 0;
+        margin-top: -0.52em;
+        margin-left: 0.46em;
+    }
+    
+    &:hover, &:focus{
+        background: #DDE8EC;
+    }
+    
+    &:active{
+        background: #d4dfe3;
+    }
+    
+}


### PR DESCRIPTION
I've added some styling for the video links. I used pure css with :before & :after pseudo elements to create the play button icon and circle. Not sure if that will cause any issues when converted to app form, but hopefully not since it's a web view in the end. I've attached a screenshot of how it should look as the content within the funzo app has not been updated with the version that has the video links as of now.

<img width="248" alt="video-links" src="https://cloud.githubusercontent.com/assets/306632/16685619/ef757e1c-4514-11e6-92f4-7b18ec4b3716.png">
