### PR TITLE
Simplified design for video links

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -203,53 +203,25 @@ blockquote {
 
 a.video_link {
     line-height: 1em;
-    /*position: relative;*/
-    border: 1px solid $brand-primary;
-    margin: 1em 1em 1em 0em;
-    /* padding: 0.9em 1em 1em 3em; */
-    padding: 0.9em 1em 1em 0.9em;
-    border-radius: 1000px;
+    margin: 0em 0em 0em 0em;
+    padding: 1em;
     background: transparent;
     color: $brand-primary;
     text-decoration: none;
     display: table;
-    
-    &:before {
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 0.6em 0em 0.6em 0.9em;
-        border-color: transparent transparent transparent #FFFFFF;
-        left: 1.2em;
-        position: absolute;
-        content: '';
-        color: red;
-        padding: 0;
-        top: 0.8em;
-        z-index: 1;
-        -webkit-transform: rotate(360deg);
-    }
-
-    &:after {
-        position: absolute;
-        content: '';
-        padding: 1em;
-        border: 1px solid $brand-primary;
-        border-radius: 1000px;
-        line-height: 1;
-        background-color: $brand-primary;
-        left: 0;
-        margin-top: -0.52em;
-        margin-left: 0.46em;
-    }
+    border-radius: 1000px;
+    border-color: $brand-primary;
+    border: 1px solid $brand-primary;
     
     &:hover, &:focus{
-        background: #DDE8EC;
+        background: $brand-primary;
+        color: #FFFFFF;
     }
     
     &:active{
-        background: #d4dfe3;
-    }  
+        background: $brand-primary;
+        color: #DDE8EC;
+    }
 }
 
 @import "components/reader";


### PR DESCRIPTION
This is a simplified design for the video links - basically just made it look like a ghost button.

The earlier design had issues with positioning the pseudo elements for when the video link was more than 1 line - I forgot to consider that before. I tried putting a Play video link below the video title, but somehow any element with `position: relative;` seems to make all the text in that element transparent from Part 3 onwards. Very weird bug - so in interests of time, I think this simplified version will work. We can revisit and improve it later. 