### PR TITLE
Fix all jshint warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cordova/plugins
 
 # funzo
 public/content/courses
+ 

--- a/app/pods/application/adapter.js
+++ b/app/pods/application/adapter.js
@@ -15,7 +15,7 @@ export default Adapter.extend({
       let keyForModel = Ember.String.pluralize(type.modelName);
       // FIXME: This is a terrible hack to work around I don't even
       // know what with Ember.
-      if (keyForModel == "x-api-statements") {
+      if (keyForModel === "x-api-statements") {
         keyForModel = "xApiStatements";
       }
       let filterFunction = (item) => {

--- a/app/pods/application/route.js
+++ b/app/pods/application/route.js
@@ -27,6 +27,7 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   // we might want to go back to that, but for now one sync per statement
   // lets us get around our weird query issues
   syncStatement(statement) {
+    /* global TinCan */
     var xapi = new TinCan(ENV.APP.xAPI);
     var xApiStatements = [];
     xApiStatements.addObject(statement);
@@ -47,9 +48,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
 
   /* extracted recordxAPI promises here */
 
-  fetchUser(resolve, reject) {
+  fetchUser() {
     var user = this.get('currentUser.model');
-    resolve(user);
+    return user;
   },
 
   storeXAPIStatement(user, statement_data) {

--- a/app/pods/application/serializer.js
+++ b/app/pods/application/serializer.js
@@ -3,7 +3,7 @@ import DS from 'ember-data';
 export default DS.RESTSerializer.extend({
   primaryKey: 'permalink',
 	modelNameFromPayloadKey(key) {
-		if (key == "xApiStatements") {
+		if (key === "xApiStatements") {
 			return "x-api-statement";
 		} else {
 			return key;

--- a/app/pods/book-manager/service.js
+++ b/app/pods/book-manager/service.js
@@ -1,4 +1,3 @@
-/* global LocalFileSystem */
 import Ember from 'ember';
 import ENV from 'funzo-app/config/environment';
 

--- a/app/pods/book/controller.js
+++ b/app/pods/book/controller.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { $, ObjectProxy, computed } = Ember;
+const { $, ObjectProxy, computed } = Ember; // jshint ignore:line
 
 let SectionDecorator = ObjectProxy.extend({
   isHidden: false,
@@ -14,7 +14,10 @@ export default Ember.Controller.extend({
   section: Ember.inject.controller('book.section'),
   bookmarks: Ember.inject.service(),
 
-  sections: computed.map('model.sections', function(model, i) {
+  // this method can take a second argument, but since we're not
+  // using it right now jshint will complain if it's references.
+  //sections: computed.map('model.sections', function(model, i) {
+  sections: computed.map('model.sections', function(model) {
     return SectionDecorator.create({ content: model });
   }),
 

--- a/app/pods/book/model.js
+++ b/app/pods/book/model.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 import { Model } from 'ember-pouch';
 

--- a/app/pods/book/section/route.js
+++ b/app/pods/book/section/route.js
@@ -27,7 +27,7 @@ export default Ember.Route.extend(NavBarTitleMixin, {
   hideStatusBar: function() {
     this.set('indexOnly', true);
     this.set('showBackButton', true);
-    window.StatusBar && window.StatusBar.hide();
+    if (window.StatusBar) { window.StatusBar.hide(); }
 
     document.addEventListener('resume', this.hideStatusBarResume, false);
 
@@ -35,14 +35,14 @@ export default Ember.Route.extend(NavBarTitleMixin, {
 
   showStatusBar: function() {
     this.set('indexOnly', false);
-    window.StatusBar && window.StatusBar.show();
+    if (window.StatusBar) { window.StatusBar.show(); }
 
     document.removeEventListener('resume', this.hideStatusBarResume, false);
 
   }.on('deactivate'),
 
   hideStatusBarResume() {
-    window.StatusBar && window.StatusBar.hide();
+    if (window.StatusBar) { window.StatusBar.hide(); }
   }
 });
 

--- a/app/pods/components/a-book/component.js
+++ b/app/pods/components/a-book/component.js
@@ -296,7 +296,7 @@ export default Ember.Component.extend({
     return new RSVP.Promise((resolve) => {
       let imagesLoaded = 0;
       let images = this.$('p img');
-      images.load((e) => {
+      images.load(() => {
         imagesLoaded++;
         if (images.length === imagesLoaded) {
           resolve();
@@ -366,7 +366,7 @@ export default Ember.Component.extend({
       console.log("left:", left, "start:", startPosition, "end:", endPosition);
       console.groupEnd();
 
-      if (i !== 0) prev.set('endPosition', endPosition);
+      if (i !== 0) { prev.set('endPosition', endPosition); }
       section.set('startPosition', startPosition);
     });
     console.groupEnd();

--- a/app/pods/crypto/service.js
+++ b/app/pods/crypto/service.js
@@ -9,9 +9,6 @@ export default Ember.Service.extend({
         let encryption = section.get('encryption');
         let expiration = section.get('expirationDate');
 
-        // This should be changed further down, so if the user
-        // ever sees this default, something has indeed gone wrong. 
-        let rendered = '<h1>Error</h1><p><em>Failed to extract book content. Please notify your school.</em></p>';
         // console.log("Expiration = " + expiration);
         if (expiration && expiration < new Date()) {
           section.set('html', Ember.String.htmlSafe(`<h1>Expired</h1><p><em>Sorry, this copy of ${section.get('book.title')} 

--- a/app/pods/index/controller.js
+++ b/app/pods/index/controller.js
@@ -11,7 +11,7 @@ export default Ember.Controller.extend({
   }),
 
   init() {
-    this.get('bookManager').on('booksUpdated', (books) => {
+    this.get('bookManager').on('booksUpdated', () => {
       // this.store.pushPayload('book', { books });
       this.store.unloadAll('book');
       this.store.findAll('book', { reload: true }).then((books) => this.set('model.books', books));

--- a/app/pods/section/model.js
+++ b/app/pods/section/model.js
@@ -1,4 +1,3 @@
-/* global CryptoJS */
 import DS from 'ember-data';
 import Ember from 'ember';
 import { Model } from 'ember-pouch';

--- a/app/pods/settings/controller.js
+++ b/app/pods/settings/controller.js
@@ -1,12 +1,8 @@
-/* global TinCan */
 import Ember from 'ember';
-import ENV from 'funzo-app/config/environment';
 
 function toArray(list) {
   return Array.prototype.slice.call(list || [], 0);
 }
-
-var xapi = new TinCan(ENV.APP.xAPI);
 
 // Call the reader.readEntries() until no more results are returned.
 function readFolder(dir) {

--- a/app/pods/user/model.js
+++ b/app/pods/user/model.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+//import Ember from 'ember';
 import DS from 'ember-data';
 import { Model } from 'ember-pouch';
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,14 +28,17 @@ module.exports = function(environment) {
 
     APP: {
       bookOnlyMode: true,
+      defaultBook: false,
+      /*
       // Set this to false to have no default
       defaultBook: {
-        code: 'demo',
-        hint: 'enter code "demo" to download an example book'
+      	code: 'demo',
+      	hint: 'enter code "demo" to download an example book'
       },
-      encryptionKeyBase: 'foobarbaz',
+      */
+      encryptionKeyBase: '0662D004-1871-4614-A16E-EC72DE625E63',
       // For directories, be sure to include a trailing '/'!
-      bookURLBase: 'http://funzo.tunapanda.org/content/dl/',
+      bookURLBase: 'http://elibrary.certell.org/books/',
       xAPI: {
         recordStores: [{
           endpoint: 'http://lrs.tunapanda.org/data/xAPI/',


### PR DESCRIPTION
This includes all of the warnings listed below, and the app seems to work, but a quick sanity check would be nice. 

`ember test` fails, but then it does that with a clean checkout of master for me.

```
pods/application/adapter.js: line 18, col 25, Expected '===' and instead saw '=='.
pods/application/route.js: line 50, col 22, 'reject' is defined but never used.
pods/application/route.js: line 30, col 20, 'TinCan' is not defined.
pods/application/serializer.js: line 6, col 19, Expected '===' and instead saw '=='.
pods/book-manager/service.js: line 1, col 1, 'LocalFileSystem' is defined but never used.
pods/book/controller.js: line 17, col 60, 'i' is defined but never used.
pods/book/controller.js: line 2, col 9, '$' is defined but never used.
pods/book/model.js: line 11, col 10, 'Ember' is not defined.
pods/book/section/route.js: line 30, col 47, Expected an assignment or function call and instead saw an expression.
pods/book/section/route.js: line 38, col 47, Expected an assignment or function call and instead saw an expression.
pods/book/section/route.js: line 45, col 47, Expected an assignment or function call and instead saw an expression.
pods/components/a-book/component.js: line 299, col 20, 'e' is defined but never used.
pods/components/a-book/component.js: line 369, col 20, Expected '{' and instead saw 'prev'.
pods/crypto/service.js: line 14, col 13, 'rendered' is defined but never used.
pods/index/controller.js: line 14, col 49, 'books' is defined but never used.
pods/section/model.js: line 1, col 1, 'CryptoJS' is defined but never used.
pods/settings/controller.js: line 9, col 5, 'xapi' is defined but never used.
pods/user/model.js: line 1, col 8, 'Ember' is defined but never used.
```